### PR TITLE
Cache stuff

### DIFF
--- a/bin/lib/images.sh
+++ b/bin/lib/images.sh
@@ -54,6 +54,20 @@ function makeThumbnail
     fi
 }
 
+function getDimensions
+{
+    local dimCache="intermediate/dimCache"
+    mkdir -p "$dimCache"
+    local key="$(echo "$(pwd)/$1" | md5sum | cut -d\  -f1)"
+    local dimCacheFile="$dimCache/$key"
+
+    if [ ! -e "$dimCacheFile" ]; then
+        identify -format "%w %h" "$1" | sed 's/ .* / /g' > "$dimCacheFile"
+    fi
+
+    cat "$dimCacheFile"
+}
+
 function imageMaxSize
 {
     local imageInFile="$1"
@@ -64,7 +78,7 @@ function imageMaxSize
     if [ -e "$imageOutFile" ]; then
         true # Don't do anything if we already have it. This can be re-done by doing a ./bin/freshBuild
     elif [ -e "$imageInFile" ]; then
-        read x y < <(identify -format "%w %h" "$imageInFile" | sed 's/ .* / /g')
+        read x y < <(getDimensions "$imageInFile")
 
         echo "imageMaxSize: Comparing $x to $y. imageMaxSize=$imageMaxSize. file=$imageInFile" >&2
         if [ "$x" -gt "$y" ]; then

--- a/bin/lib/masks.sh
+++ b/bin/lib/masks.sh
@@ -40,9 +40,19 @@ function maskImage
     local resolution="$4"
     local prefix="maskImage $fileIn => $resolution:    "
 
+    local maskCache="intermediate/maskCache"
+    mkdir -p "$maskCache"
+    local cacheFile="$maskCache/$(echo "$fileIn $maskFile $resolution" | md5sum | cut -d\  -f1)"
+
     if [ -e "$fileOut" ]; then
         # We've already done this.
         echo "${prefix}Skipping (Already done)."
+        return 0
+    fi
+
+    if [ -e "$cacheFile" ]; then
+        echo "${prefix}Skipping (Using cached file)."
+        cp "$cacheFile" "$fileOut"
         return 0
     fi
 
@@ -79,6 +89,8 @@ function maskImage
         echo "${prefix}$fileOut (fileOut) does not exist in $(pwd)." >&2
         return 1
     fi
+
+    cp "$fileOut" "$cacheFile"
     echo "${prefix}Masked."
 
     rm -f "$fileIn.scaled"


### PR DESCRIPTION
Add caching for

* Masked images - Some title images are used by several posts, but should only be processed once.
* Image size lookups - When deciding if and how an image should be resized, the dimensions lookup is quite expensive and we need to do it multiple times per image. Eg Thumbnails vs title images.