### PR TITLE
Decrease thread wait time

### DIFF
--- a/bin/lib/threading.sh
+++ b/bin/lib/threading.sh
@@ -19,7 +19,7 @@ function cpuCores
 # Default settings that can be overridden in the app's config.
 maxThreads="$(cpuCores)"
 threadPoolDir="/tmp/threadPool-$$"
-threadPoolInterval="0.5"
+threadPoolInterval="0.1"
 
 function prepareThreadPool
 {


### PR DESCRIPTION
0.5 was just a starting point, but we only need to throttle the loop, we don't need to wait for a long time. Meanwhile those 0.5 seconds add up pretty quickly.

Changing it to 0.1 brings the cached build time from ~25 seconds to 13 seconds.